### PR TITLE
Unit Conversion Error (NGWPC-7604)

### DIFF
--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -150,10 +150,13 @@ GetVarUnits(std::string name)
 {
   if (name.compare("ground_temperature") == 0 || name.compare("soil_temperature_profile") == 0)
     return "K";
-  else if (name.compare("ice_fraction_schaake") == 0)
-    return "m";
   else if (name.compare("ground_heat_flux") == 0)
     return "W m-2";
+  else if (name.compare("ice_fraction_schaake") == 0 ||
+           name.compare("ice_fraction_xinanjiang") == 0 ||
+           name.compare("soil_ice_fraction") == 0 ||
+           name.compare("soil_moisture_profile") == 0)
+    return "1"; // UDUNITS dimensionless
   else
     return "none";
 }


### PR DESCRIPTION


## Changes

Fixed the BMI unit metadata so that ice-fraction variables are reported as dimensionless ("1") instead of "none" (or any accidental "m").  ice_fraction_schaake / ice_fraction_xinanjiang (and any related fraction outputs) now return "1" from GetVarUnits (or equivalent), and any internal uses of "none" are normalized to "1".

Why: UDUNITS can’t parse "none", and mismatches like m

## Testing

Not getting any unit error.

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support
- [ ] Linux


