### PR TITLE
Adapt serialization to revised protocol

### DIFF
--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -101,7 +101,8 @@ GetVarGrid(std::string name)
     return 2; // arrays
   else if (name.compare("serialization_state") == 0)
     return 3; // char
-  else if (name.compare("serialization_create") == 0)
+  else if (name.compare("serialization_create") == 0
+           || name.compare("serialization_size") == 0)
     return 4; // unit64_t
   else
     return -1;
@@ -335,8 +336,7 @@ GetValuePtr (std::string name)
     return (void*)(&this->state->satpsi);
   else if (name.compare("serialization_state") == 0)
     return (void*)(this->m_serialized_vec.data());
-  else if (name.compare("serialization_create") == 0) {
-    this->new_serialized();
+  else if (name.compare("serialization_size") == 0) {
     return (void*)(&this->m_serialized_length);
   }
   else {
@@ -386,9 +386,8 @@ SetValue (std::string name, void *src)
     this->load_serialized((char*)src);
     return;
   } else if (name.compare("serialization_create") == 0) {
-    auto msg = "Cannot set value using \"serialization_create\".";
-    Logger::Log(LogLevel::WARNING, msg);
-    throw std::runtime_error(msg);
+    this->new_serialized();
+    return;
   } else {
     dest = this->GetValuePtr(name);
   }


### PR DESCRIPTION
The earlier BMI state saving protocol was not going to be tenable on Fortran due to intent(in) dummy arguments. This revision simplifies the protocol such that SetValue is used for mutating actions, and GetValue/GetValuePtr are used for queries.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: