### PR TITLE
Add log message before config file asserts (NGWPC-8384)

### DIFF
--- a/src/soil_freeze_thaw.cxx
+++ b/src/soil_freeze_thaw.cxx
@@ -44,6 +44,9 @@ SoilFreezeThaw()
 
 soilfreezethaw::SoilFreezeThaw::
 SoilFreezeThaw(std::string config_file)
+: soil_z(), soil_dz(), soil_temperature(), soil_temperature_prev(),
+  heat_capacity(), thermal_conductivity(),
+  soil_moisture_content(), soil_liquid_content(), soil_ice_content()
 {
   this->latent_heat_fusion = 0.3336E06;
   

--- a/src/soil_freeze_thaw.cxx
+++ b/src/soil_freeze_thaw.cxx
@@ -190,7 +190,10 @@ InitFromConfigFile(std::string config_file)
     else if (param_key == "b" || param_key == "soil_params.b") {
       this->b = std::stod(param_value);
       std::string b_unit = line.substr(loc_u+1,line.length());
-      assert (this->b > 0);
+      if ( !(this->b > 0)) {
+        LOG(LogLevel::FATAL, "%s=%f is invalid. Must be > 0. Source file: %s", param_key.c_str(), this->b, config_file.c_str());
+        assert(this->b > 0);
+      }
       is_b_set = true;
       continue;
     }
@@ -198,7 +201,10 @@ InitFromConfigFile(std::string config_file)
     // See https://github.com/NOAA-OWP/SoilFreezeThaw/pull/14#issuecomment-1864879127 for discussion
     else if (param_key == "quartz" || param_key == "soil_params.quartz") {
       this->quartz = std::stod(param_value);
-      assert (this->quartz > 0);
+      if ( !(this->quartz > 0)) {
+        LOG(LogLevel::FATAL, "%s=%f is invalid. Must be > 0. Source file: %s", param_key.c_str(), this->quartz, config_file.c_str());
+        assert(this->quartz > 0);
+      }
       is_quartz_set = true;
       continue;
     }
@@ -327,9 +333,13 @@ InitFromConfigFile(std::string config_file)
   this->option_top_boundary = is_top_boundary_temp_set == true ? 1 : 2; // 1: constant temp, 2: from a file
 
   // check if the size of the input data is consistent
-  assert (n_st == this->ncells);
-  assert (n_mct == this->ncells);
-  assert (n_mcl == this->ncells);
+  if ( !(n_st == this->ncells) || !(n_mct == this->ncells) || !(n_mcl == this->ncells) ) {
+    LOG(LogLevel::FATAL, "%s: Size of input data inconsistent. ncells=%d: n_st=%d, n_mct=%d, n_mcl=%d",
+        config_file.c_str(), this->ncells, n_st, n_mct, n_mcl);
+    assert(n_st == this->ncells);
+    assert(n_mct == this->ncells);
+    assert(n_mcl == this->ncells);
+  }
 }
 
 /*
@@ -399,7 +409,11 @@ ComputeIceFraction()
     for (int i =0; i < ncells; i++) {
       val += this->soil_ice_content[i] * this->soil_dz[i];
     }
-    assert (this->ice_fraction_schaake <= this->soil_depth);
+    if ( !(this->ice_fraction_schaake <= this->soil_depth) ) {
+        LOG(LogLevel::FATAL, "ice_fraction_schaake %f > soil_depth %f",
+            this->ice_fraction_schaake, this->soil_depth);
+        assert(this->ice_fraction_schaake <= this->soil_depth);
+    }
     this->ice_fraction_schaake = val;
   }
   else if (this->ice_fraction_scheme_bmi == SurfaceRunoffScheme::Xinanjiang) {
@@ -521,7 +535,10 @@ GroundHeatFlux(double soil_temp)
     return 0;
   }
 
-  assert (this->soil_z[0] >0);
+  if ( !(this->soil_z[0] >0)) {
+    LOG(LogLevel::FATAL, "soil_z[0] = %f is invalid. Must be > 0.", this->soil_z[0]);
+    assert(this->soil_z[0] >0);
+  }
   double ground_heat_flux_loc = - thermal_conductivity[0] * (soil_temp  - surface_temp) / (0.5*soil_z[0]); // half of top cell thickness
   
   return ground_heat_flux_loc;

--- a/src/soil_freeze_thaw.cxx
+++ b/src/soil_freeze_thaw.cxx
@@ -150,11 +150,11 @@ InitFromConfigFile(std::string config_file)
       this->endtime = std::stod(param_value);
 
       if (param_unit == "[d]" || param_unit == "[day]") 
-	this->endtime *= 86400;
+	      this->endtime *= 86400;
       else if (param_unit == "[s]" || param_unit == "[sec]")
-	this->endtime *= 1.0;
+	      this->endtime *= 1.0;
       else if (param_unit == "[h]" || param_unit == "[hr]" || param_unit == "") // defalut time unit is hour
-	this->endtime *= 3600.0;
+	      this->endtime *= 3600.0;
 
       is_endtime_set = true;
       continue;
@@ -162,11 +162,11 @@ InitFromConfigFile(std::string config_file)
     else if (param_key == "dt") {
       this->dt = std::stod(param_value);
       if (param_unit == "[d]" || param_unit == "[day]")
-	this->dt *= 86400;
+	      this->dt *= 86400;
       else if (param_unit == "[s]" || param_unit == "[sec]")
-	this->dt *= 1.0;
+	      this->dt *= 1.0;
       else if (param_unit == "[h]" || param_unit == "[hr]" || param_unit == "") // defalut time unit is hour
-	this->dt *= 3600.0;
+	      this->dt *= 3600.0;
       
       is_dt_set = true;
       continue;


### PR DESCRIPTION
Asserts were triggered without enough information to determine the cause. There could be missing symbols in the build process so added initialization in the constructor. 

## Additions

- Added log messages that provided more detail, specifically which BMI config file was causing the issue.
- Add constructor initialization for some needed symbols

## Changes

- Minor formatting indentation fixes

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

