### PR TITLE
Update quartz validation to allow 0 (NGWPC-8331)

### DIFF
--- a/src/soil_freeze_thaw.cxx
+++ b/src/soil_freeze_thaw.cxx
@@ -201,7 +201,7 @@ InitFromConfigFile(std::string config_file)
     // See https://github.com/NOAA-OWP/SoilFreezeThaw/pull/14#issuecomment-1864879127 for discussion
     else if (param_key == "quartz" || param_key == "soil_params.quartz") {
       this->quartz = std::stod(param_value);
-      if ( !(this->quartz > 0)) {
+      if ( !(this->quartz >= 0)) {
         LOG(LogLevel::FATAL, "%s=%f is invalid. Must be > 0. Source file: %s", param_key.c_str(), this->quartz, config_file.c_str());
         assert(this->quartz > 0);
       }


### PR DESCRIPTION
There is a check for `>0` in the `ThermalConductivity` method when reading the `quartz` value from the BMI config file. The source documents used by EDFS from Deltares on the [BMI Exchange Items and Module Parameters](https://confluence.nextgenwaterprediction.com/display/NGWPC/BMI+Exchange+Items+and+Module+Parameters) confluence page, indicate the valid min for this `quartz` is `0`. Some catchment BMI files for several gauges had this value set to the min of 0 causing SFT to fail. Investigating the ramifications of the `quartz` parameter being set to `0` determined there were none, mathematically. The only equations using it would result in `tc_mineral` being set to `3` which appears to be ok for the remainder of the method. Per direction of the SME, updated this assert to allow of a value of `>= 0`.

## Changes

- Updated assert for the BMI config file parameters quartz to test for `>=0`

## Testing

1. Ran ngen with a gauge 01011000, which had previously failed before the timesteps started, and confirmed it successfully ran at least 1000 timesteps. Since this is a 381 catchment basin, did not run until completion of 26000 timesteps in AWS workspace. Instead, will merge and test in the PW environment, which is significantly faster.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
