### PR TITLE
Add definition of GetLogLevel to Logger source file

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -282,10 +282,6 @@ void Logger::SetLoggingFlag(void) {
     std::cout << MODULE_NAME << " Logging " << ((loggingEnabled)?"ENABLED":"DISABLED") << std::endl;
 }
 
-bool Logger::IsLoggingEnabled(void) {
-    return loggingEnabled;
-}
-
 void Logger::SetLogModuleName(void) {
     // Make sure the module name used for logging entries is all uppercase and 8 characters wide.
     moduleName            = MODULE_NAME;
@@ -421,3 +417,11 @@ std::string Logger::CreateTimestamp(bool appendMS, bool iso) {
 std::string Logger::GetLogFilePath() {
     return logFilePath;
 }
+
+bool Logger::IsLoggingEnabled(void) {
+    return loggingEnabled;
+}
+
+LogLevel Logger::GetLogLevel(void) {
+    return logLevel;
+} 


### PR DESCRIPTION
The GetLogLevel method was declared in the Logger.hpp file but not defined in the Logger.cpp file.

## Additions

- Added GetLogLevel method definition in Logger source file

## Changes

- Moved IsLoggingEnabled to end of file with GetLogLevel

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
