### PR TITLE
Implement reset_time Function (NGWPC-9619)

### DIFF
--- a/include/bmi_soil_freeze_thaw.hxx
+++ b/include/bmi_soil_freeze_thaw.hxx
@@ -88,6 +88,7 @@ class BmiSoilFreezeThaw : public bmi::Bmi {
     void new_serialized();
     void load_serialized(char* data);
     void clear_serialized();
+    void reset_time();
 };
 
 #ifdef NGEN

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -28,6 +28,9 @@ public:
     // Forwarder for std::vector::clear()
     constexpr void clear() { vector_.clear(); }
 
+    // Forwarder for std::vector::resize(size)
+    constexpr void resize(size_type size) { vector_.resize(size); }
+
     // Forwarder for std::vector::reserve
     constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
 
@@ -35,7 +38,7 @@ public:
     constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
 
     // Forwarder for std::vector::data
-    constexpr const value_type* data() const { return vector_.data(); }
+    constexpr value_type* data() { return vector_.data(); }
 
     // Forwarder for std::vector::size
     constexpr size_type size() const { return vector_.size(); }
@@ -110,6 +113,13 @@ private:
         return written;
     }
 
+};
+
+class membuf : public std::streambuf {
+public:
+    membuf(char *begin, size_t size) {
+        this->setg(begin, begin, begin + size);
+    }
 };
 
 #endif

--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -597,11 +597,15 @@ serialize(Archive& ar, const unsigned int version) {
 
 void BmiSoilFreezeThaw::
 new_serialized() {
-  this->m_serialized_vec.clear();
+  // resize to reserve space for the serialized size as a header
+  this->m_serialized_vec.resize(sizeof(uint64_t));
   boost::archive::binary_oarchive archive(this->m_serialized_vec);
   try {
     archive << (*this);
     this->m_serialized_length = this->m_serialized_vec.size();
+    // copy size of serialized data to the beginning as a header
+    uint64_t serialized_size = this->m_serialized_length - sizeof(uint64_t);
+    memcpy(this->m_serialized_vec.data(), &serialized_size, sizeof(uint64_t));
   } catch (const std::exception &e) {
     Logger::Log(LogLevel::SEVERE, "Serializing SFT encountered an error: %s", e.what());
     this->m_serialized_length = 0;
@@ -612,7 +616,11 @@ new_serialized() {
 
 void BmiSoilFreezeThaw::
 load_serialized(char* data) {
-  std::stringstream stream(data);
+  // pull data size from header of raw data ptr
+  uint64_t size;
+  memcpy(&size, data, sizeof(uint64_t));
+  // create stream from after the size header
+  membuf stream(data + sizeof(uint64_t), size);
   boost::archive::binary_iarchive archive(stream);
   try {
     archive >> (*this);

--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -95,7 +95,8 @@ GetVarGrid(std::string name)
   else if (name.compare("ground_temperature") == 0 || name.compare("ice_fraction_schaake") == 0
 	   || name.compare("ice_fraction_xinanjiang") == 0 || name.compare("soil_ice_fraction") == 0
 	   || name.compare("ground_heat_flux") == 0 || name.compare("smcmax") == 0
-	   || name.compare("b") == 0 || name.compare("satpsi") == 0)
+	   || name.compare("b") == 0 || name.compare("satpsi") == 0
+     || name == "reset_time")
     return 1; //double
   else if (name.compare("soil_moisture_profile") == 0 || name.compare("soil_temperature_profile") == 0)
     return 2; // arrays
@@ -388,6 +389,9 @@ SetValue (std::string name, void *src)
   } else if (name.compare("serialization_create") == 0) {
     this->new_serialized();
     return;
+  } else if (name == "reset_time") {
+    this->reset_time();
+    return;
   } else {
     dest = this->GetValuePtr(name);
   }
@@ -626,6 +630,12 @@ clear_serialized() {
   this->m_serialized_vec.clear();
   this->m_serialized_vec.shrink_to_fit();
   this->m_serialized_length = 0;
+}
+
+void BmiSoilFreezeThaw::
+reset_time() {
+  // time doesn't seem to be used anywhere but GetCurrentTime, so safe to set to 0 and nothing else
+  this->state->time = 0.0;
 }
 
 


### PR DESCRIPTION
Hindcasting requires resetting the time to 0 after loading a state that contains the current time. This change adds a `SetValue` message variable `"reset_time'` that allows the BMI to reset its time to 0 as a separate message that will be given after the load.

## Additions

- `reset_time` member function that sets the BMI's state's time to 0. No other actions appear to be needed to set the BMI in a usable state.

## Changes

- Add `"reset_time"` message to `SetValue` to trigger resetting the time to 0.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
