### PR TITLE
Fix for incorrectly identified log messages

### DIFF
--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -2,16 +2,16 @@
 #define SFT_LOGGER_HPP
 
 #include "ewts/module_constants.hpp"
-
-// Provide the constant in the global namespace
-inline constexpr const char* EWTS_ID_SFT = ewts::modules::EWTS_ID_SFT;
-
-// Bind this module's logger identity
-#define EWTS_ID EWTS_ID_SFT
-
 #include "ewts/logger.hpp"
+#include "ewts/log_levels.hpp"
+
+#define LOG(...) ::ewts::GetLogger(::ewts::modules::EWTS_ID_SFT).Log(__VA_ARGS__)
+#define GetLogLevel() ::ewts::GetLogger(::ewts::modules::EWTS_ID_SFT).GetLogLevel()
+#define IsLoggingEnabled() ::ewts::GetLogger(::ewts::modules::EWTS_ID_SFT).IsLoggingEnabled()
 
 using ewts::EwtsInit;
 using ewts::LogLevel;
+
+inline constexpr const char* SFT_MODULE_ID = ewts::modules::EWTS_ID_SFT;
 
 #endif /* SFT_LOGGER_HPP */

--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -42,9 +42,9 @@ Initialize (std::string config_file)
 {
   // Initialize the Error, Warning and Trapping System
 #ifdef EWTS_HAVE_NGEN_BRIDGE    
-  EwtsInit(EWTS_ID_SFT, true);
+  EwtsInit(SFT_MODULE_ID, true);
 #else
-  EwtsInit(EWTS_ID_SFT, false);
+  EwtsInit(SFT_MODULE_ID, false);
 #endif
   LOG(LogLevel::INFO, "Initializing SFT");
 


### PR DESCRIPTION
Remove using generic EWTS_ID and define LOG in submodule instead of relying on generic definition in ewts library which was causing log messages to be incorrectly identified in the logs.