### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ target_link_libraries(sftbmi PRIVATE ewts::ewts_cpp)
 # Built with ngen bridge
 target_link_libraries(sftbmi PRIVATE 
     "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed")
-target_compile_definitions(sftbmi PRIVATE EWTS_HAVE_NGEN_BRIDGE)
+target_compile_definitions(sftbmi PRIVATE USE_EWTS)
 
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,17 +113,24 @@ set_target_properties(sftbmi PROPERTIES PUBLIC_HEADER ./include/bmi_soil_freeze_
 
 target_link_libraries(sftbmi PRIVATE Boost::serialization)
 
-# --- EWTS (installed from nwm-ewts) ---
-find_package(ewts CONFIG REQUIRED)
+option(USE_EWTS "Build SFT with EWTS logging" ON)
+message("-- SFT CMakeLists USE_EWTS = ${USE_EWTS}")
+if(USE_EWTS)
+    message("-- SFT compiled with EWTS logging")
 
-# Always use EWTS runtime logger for CPP
-target_link_libraries(sftbmi PRIVATE ewts::ewts_cpp)
+    # --- EWTS (installed from nwm-ewts) ---
+    find_package(ewts CONFIG REQUIRED)
 
-# Built with ngen bridge
-target_link_libraries(sftbmi PRIVATE 
-    "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed")
-target_compile_definitions(sftbmi PRIVATE USE_EWTS)
+    # Always use EWTS runtime logger for CPP
+    target_link_libraries(sftbmi PRIVATE ewts::ewts_cpp)
 
+    # Built with ngen bridge
+    target_link_libraries(sftbmi PRIVATE 
+        "-Wl,--no-as-needed" ewts::ewts_ngen_bridge "-Wl,--as-needed")
+    target_compile_definitions(sftbmi PRIVATE SFT_USE_EWTS)
+else()
+    message("-- SFT compiled with stdout fallback logging")
+endif()
 
 include(GNUInstallDirs)
 

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,6 +1,11 @@
 #ifndef SFT_LOGGER_HPP
 #define SFT_LOGGER_HPP
 
+#ifdef SFT_USE_EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Using EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 #include "ewts/module_constants.hpp"
 #include "ewts/logger.hpp"
 #include "ewts/log_levels.hpp"
@@ -13,5 +18,134 @@ using ewts::EwtsInit;
 using ewts::LogLevel;
 
 inline constexpr const char* SFT_MODULE_ID = ewts::modules::EWTS_ID_SFT;
+
+#else
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Log messages written to STDOUT
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+#include <chrono>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+inline constexpr const char* SFT_MODULE_ID = "SFT";
+
+// Minimal LogLevel enum (match EWTS values if possible)
+enum class LogLevel {
+    NOTSET = 0,
+    DEBUG = 10,
+    INFO = 20,
+    WARNING = 30,
+    SEVERE = 40,
+    FATAL = 50
+};
+
+#define SFT_FALLBACK_LOGGING_ENABLED   1
+#define SFT_FALLBACK_LOG_LEVEL         LogLevel::INFO
+
+inline std::string sft_utc_timestamp() {
+    using clock = std::chrono::system_clock;
+    auto now = clock::now();
+    auto tt = clock::to_time_t(now);
+
+    std::tm tm{};
+    gmtime_r(&tt, &tm);
+
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now.time_since_epoch()) % 1000;
+
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S")
+        << '.' << std::setw(3) << std::setfill('0') << ms.count()
+        << 'Z';
+
+    return oss.str();
+}
+
+inline std::string_view sft_rstrip_newline(std::string_view s) {
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) {
+        s.remove_suffix(1);
+    }
+    return s;
+}
+
+inline const char* sft_level_to_string(LogLevel level) {
+    switch (level) {
+        case LogLevel::DEBUG:   return "DEBUG";
+        case LogLevel::INFO:    return "INFO";
+        case LogLevel::WARNING: return "WARN";
+        case LogLevel::SEVERE:  return "ERROR";
+        case LogLevel::FATAL:   return "FATAL";
+        default:                return "LOG";
+    }
+}
+
+inline bool IsLoggingEnabled() {
+    return SFT_FALLBACK_LOGGING_ENABLED;
+}
+
+inline LogLevel GetLogLevel() {
+    return SFT_FALLBACK_LOG_LEVEL;  // simple default
+}
+
+inline void Log(LogLevel level, std::string_view message) {
+
+    if (message.empty()) return;
+    if (!IsLoggingEnabled()) return;
+    if (level < GetLogLevel()) return;
+
+    std::ostringstream oss;
+
+    message = sft_rstrip_newline(message);
+
+    oss << sft_utc_timestamp() << " "
+        << SFT_MODULE_ID << " "
+        << sft_level_to_string(level) << " "
+        << message << '\n';
+
+    std::cout << oss.str() << std::flush;   
+}
+
+inline void Log(std::string_view message, LogLevel level) {
+    Log(level, message);
+}
+
+inline void Log(LogLevel level, const char* fmt, ...) {
+    if (!fmt) return;
+    if (!IsLoggingEnabled()) return;
+    if (level < GetLogLevel()) return;
+
+    va_list args;
+    va_start(args, fmt);
+
+    va_list args_copy;
+    va_copy(args_copy, args);
+    int len = std::vsnprintf(nullptr, 0, fmt, args_copy);
+    va_end(args_copy);
+
+    if (len < 0) {
+        va_end(args);
+        return;
+    }
+
+    std::string buffer(static_cast<std::size_t>(len) + 1, '\0');
+    std::vsnprintf(buffer.data(), buffer.size(), fmt, args);
+    va_end(args);
+
+    buffer.resize(static_cast<std::size_t>(len));
+
+    Log(level, buffer);
+}
+
+#define LOG(...) Log(__VA_ARGS__)
+#endif
 
 #endif /* SFT_LOGGER_HPP */

--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -40,12 +40,14 @@ BmiSoilFreezeThaw::BmiSoilFreezeThaw() : m_serialized_vec{} {
 void BmiSoilFreezeThaw::
 Initialize (std::string config_file)
 {
-  // Initialize the Error, Warning and Trapping System
-#ifdef USE_EWTS    
+#ifdef SFT_USE_EWTS    
+  // Initialize the Error and Warning Trapping System
+  #pragma message("SoilFreezeThaw.bmi_soil_freeze_thaw.Initialize: SFT_USE_EWTS ON")
   EwtsInit(SFT_MODULE_ID, true);
 #else
-  EwtsInit(SFT_MODULE_ID, false);
+  #pragma message("SoilFreezeThaw.bmi_soil_freeze_thaw.Initialize: SFT_USE_EWTS OFF")
 #endif
+
   LOG(LogLevel::INFO, "Initializing SFT");
 
   if (config_file.compare("") != 0 )

--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -41,7 +41,7 @@ void BmiSoilFreezeThaw::
 Initialize (std::string config_file)
 {
   // Initialize the Error, Warning and Trapping System
-#ifdef EWTS_HAVE_NGEN_BRIDGE    
+#ifdef USE_EWTS    
   EwtsInit(SFT_MODULE_ID, true);
 #else
   EwtsInit(SFT_MODULE_ID, false);


### PR DESCRIPTION
Exclude ewts when `SFT_USE_EWTS` preprocessor symbol is not defined. This symbol is set in the `CMakeFiles.txt` based on the `USE_EWTS` symbol.

## Additions

- Added check for `SFT_USE_EWTS`. When defined include the ewts library and initialize the ewts logger, otherwise fallback to stdout logging

## Removals

- Initializing the ewts logger when `USE_EWTS` is not defined. Log messages will be sent to stdout

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`