### PR TITLE
Revert setting grid 0 to scalar. Fix return from GetGridRank.

### DIFF
--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -258,9 +258,7 @@ GetGridOrigin (const int grid, double *origin)
 int BmiSoilFreezeThaw::
 GetGridRank(const int grid)
 {
-  if (grid == 0 || grid == 1 || grid == 3 || grid == 4)
-    return 0;
-  else if (grid == 2)
+  if (grid == 0 || grid == 1 || grid == 2 || grid == 3 || grid == 4)
     return 1;
   else
     return -1;
@@ -285,10 +283,10 @@ GetGridSize(const int grid)
 std::string BmiSoilFreezeThaw::
 GetGridType(const int grid)
 {
-  if (grid == 0 || grid == 1 || grid == 3 || grid == 4)
-    return "scalar";
-  else if (grid == 2)
+  if (grid == 0)
     return "uniform_rectilinear";
+  else if (grid == 1 || grid == 2 || grid == 3 || grid == 4)
+    return "scalar";
   else {
     std::string errMsg = "Grid " + std::to_string(grid) + " does not exist";
     LOG(LogLevel::FATAL, errMsg);


### PR DESCRIPTION
When the BMI fixes were merged in PR #21, there was not an understanding how the SFT original developer was using grid. According to Ian a BMI grid is a way of interfacing with 3-dimensional arrays but SFT doesn't really use this concept of the grid Instead uses grid as a proxy for the data type of the variables. This PR reverts some updates that were made to the original SFT code (https://github.com/NOAA-OWP/SoilFreezeThaw/blob/master/src/bmi_soil_freeze_thaw.cxx) without this knowledge.


## Changes

- In `GetGridType`, return "uniform_rectilinear" for grid 0 and "scalar" for all other grid types.
- Int `GetGridRank` a return of `1` was changed to `0` for grids 0, 1 and 2, which would result in a failure response, according to the unit tests. Reverted to returning 1 for these grids, as well as the new serialization grids 3 and 4. 

## Testing

Rebuilt ngen with the SFT updates and successfully ran a calibration through ngenCERF using SFT in a formulation on gage 01123000.
