### PR TITLE
Add BMI Output Variables to Save State (NGWPC-11588)

### DIFF
--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -631,6 +631,9 @@ serialize(Archive& ar, const unsigned int version) {
 
   // in EnergyBalanceCheck
   ar & state->energy_balance;
+
+  // BMI output vars
+  ar & state->ncells;
 }
 
 


### PR DESCRIPTION
Expand the values saved to include any variables exposed by the list of output variables. These were previously omitted to keep the state size small, but it could cause problems with loading hindcasting states.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
