### PR TITLE
Use Boost for Streaming Data to Vector (NGWPC-11629)

### DIFF
--- a/include/bmi_soil_freeze_thaw.hxx
+++ b/include/bmi_soil_freeze_thaw.hxx
@@ -73,7 +73,7 @@ class BmiSoilFreezeThaw : public bmi::Bmi {
   private:
     friend class boost::serialization::access;
     soilfreezethaw::SoilFreezeThaw* state;
-    vecbuf<char> m_serialized_vec;
+    vecbuf m_serialized_vec;
     uint64_t m_serialized_length; // can theoretically always be derived from the vec's size, but needed for having a stable location for GetValuePtr
     static const int input_var_name_count  = 2;
     static const int output_var_name_count = 6;

--- a/include/vecbuf.hpp
+++ b/include/vecbuf.hpp
@@ -1,119 +1,13 @@
 #ifndef HPP_STRING_VECBUF
 #define HPP_STRING_VECBUF
-// https://gist.github.com/stephanlachnit/4a06f8475afd144e73235e2a2584b000
-// SPDX-FileCopyrightText: 2023 Stephan Lachnit
-// SPDX-License-Identifier: MIT
 
 #include <streambuf>
-#include <string>
 #include <vector>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/stream.hpp>
 
-template<class CharT = char, class Traits = std::char_traits<CharT>>
-class vecbuf : public std::basic_streambuf<CharT> {
-public:
-    using streambuf = std::basic_streambuf<CharT, Traits>;
-    using char_type = typename streambuf::char_type;
-    using int_type = typename streambuf::int_type;
-    using traits_type = typename streambuf::traits_type;
-    using vector = std::vector<char_type>;
-    using value_type = typename vector::value_type;
-    using size_type = typename vector::size_type;
-
-    // Constructor for vecbuf with optional initial capacity
-    vecbuf(size_type capacity = 0) : vector_() { reserve(capacity); }
-
-    // Forwarder for std::vector::shrink_to_fit()
-    constexpr void shrink_to_fit() { vector_.shrink_to_fit(); }
-    
-    // Forwarder for std::vector::clear()
-    constexpr void clear() { vector_.clear(); }
-
-    // Forwarder for std::vector::resize(size)
-    constexpr void resize(size_type size) { vector_.resize(size); }
-
-    // Forwarder for std::vector::reserve
-    constexpr void reserve(size_type capacity) { vector_.reserve(capacity); setp_from_vector(); }
-
-    // Increase the capacity of the buffer by reserving the current_size + additional_capacity
-    constexpr void reserve_additional(size_type additional_capacity) { reserve(size() + additional_capacity); }
-
-    // Forwarder for std::vector::data
-    constexpr value_type* data() { return vector_.data(); }
-
-    // Forwarder for std::vector::size
-    constexpr size_type size() const { return vector_.size(); }
-
-    // Forwarder for std::vector::capacity
-    constexpr size_type capacity() const { return vector_.capacity(); }
-
-    // Implements std::basic_streambuf::xsputn
-    std::streamsize xsputn(const char_type* s, std::streamsize count) override {
-        try {
-            reserve_additional(count);
-        }
-        catch (const std::bad_alloc& error) {
-            // reserve did not work, use slow algorithm
-            return xsputn_slow(s, count);
-        }
-        // reserve worked, use fast algorithm
-        return xsputn_fast(s, count);
-    }
-
-protected:
-    // Calculates value to std::basic_streambuf::pbase from vector
-    constexpr value_type* pbase_from_vector() const { return const_cast<value_type*>(vector_.data()); }
-
-    // Calculates value to std::basic_streambuf::pptr from vector
-    constexpr value_type* pptr_from_vector() const { return const_cast<value_type*>(vector_.data() + vector_.size()); }
-
-    // Calculates value to std::basic_streambuf::epptr from vector
-    constexpr value_type* epptr_from_vector() const { return const_cast<value_type*>(vector_.data()) + vector_.capacity(); }
-
-    // Sets the values for std::basic_streambuf::pbase, std::basic_streambuf::pptr and std::basic_streambuf::epptr from vector
-    constexpr void setp_from_vector() { streambuf::setp(pbase_from_vector(), epptr_from_vector()); streambuf::pbump(size()); }
-
-private:
-    // std::vector containing the data
-    vector vector_;
-
-    // Fast implementation of std::basic_streambuf::xsputn if reserve_additional(count) succeeded
-    std::streamsize xsputn_fast(const char_type* s, std::streamsize count) {
-        // store current pptr (end of vector location)
-        auto* old_pptr = pptr_from_vector();
-        // resize the vector, does not move since space already reserved
-        vector_.resize(vector_.size() + count);
-        // directly memcpy new content to old pptr (end of vector before it was resized)
-        traits_type::copy(old_pptr, s, count);
-        // reserve() already calls setp_from_vector(), only adjust pptr to new epptr
-        streambuf::pbump(count);
-
-        return count;
-    }
-
-    // Slow implementation of std::basic_streambuf::xsputn if reserve_additional(count) did not succeed, might calls std::basic_streambuf::overflow()
-    std::streamsize xsputn_slow(const char_type* s, std::streamsize count) {
-        // reserving entire vector failed, emplace char for char
-        std::streamsize written = 0;
-        while (written < count) {
-            try {
-                // copy one char, should throw eventually std::bad_alloc
-                vector_.emplace_back(s[written]);
-            }
-            catch (const std::bad_alloc& error) {
-                // try overflow(), if eof return, else continue
-                int_type c = this->overflow(traits_type::to_int_type(s[written]));
-                if (traits_type::eq_int_type(c, traits_type::eof())) {
-                    return written;
-                }
-            }
-            // update pbase, pptr and epptr
-            setp_from_vector();
-            written++;
-        }
-        return written;
-    }
-
-};
+using vecbuf = std::vector<char>;
+using OStreamType = boost::iostreams::stream<boost::iostreams::back_insert_device<vecbuf>>;
 
 class membuf : public std::streambuf {
 public:

--- a/src/bmi_soil_freeze_thaw.cxx
+++ b/src/bmi_soil_freeze_thaw.cxx
@@ -648,18 +648,26 @@ serialize(Archive& ar, const unsigned int version) {
   ar & state->ncells;
 }
 
+namespace {
+  using HeaderType = uint32_t;
+}
 
 void BmiSoilFreezeThaw::
 new_serialized() {
   // resize to reserve space for the serialized size as a header
-  this->m_serialized_vec.resize(sizeof(uint64_t));
-  boost::archive::binary_oarchive archive(this->m_serialized_vec);
+  this->m_serialized_vec.clear();
+  OStreamType stream(this->m_serialized_vec);
+  // make room for header
+  HeaderType serialized_size;
+  stream.write(reinterpret_cast<const char*>(&serialized_size), sizeof(HeaderType));
+  boost::archive::binary_oarchive archive(stream);
   try {
     archive << (*this);
+    stream.flush();
     this->m_serialized_length = this->m_serialized_vec.size();
     // copy size of serialized data to the beginning as a header
-    uint64_t serialized_size = this->m_serialized_length - sizeof(uint64_t);
-    memcpy(this->m_serialized_vec.data(), &serialized_size, sizeof(uint64_t));
+    serialized_size = this->m_serialized_length - sizeof(HeaderType);
+    memcpy(this->m_serialized_vec.data(), &serialized_size, sizeof(HeaderType));
   } catch (const std::exception &e) {
     LOG(LogLevel::SEVERE, "Serializing SFT encountered an error: %s", e.what());
     this->m_serialized_length = 0;
@@ -671,10 +679,10 @@ new_serialized() {
 void BmiSoilFreezeThaw::
 load_serialized(char* data) {
   // pull data size from header of raw data ptr
-  uint64_t size;
-  memcpy(&size, data, sizeof(uint64_t));
+  HeaderType size;
+  memcpy(&size, data, sizeof(HeaderType));
   // create stream from after the size header
-  membuf stream(data + sizeof(uint64_t), size);
+  membuf stream(data + sizeof(HeaderType), size);
   boost::archive::binary_iarchive archive(stream);
   try {
     archive >> (*this);


### PR DESCRIPTION
OWP found errors with the original structure of the `vecbuf` class used for serialization. This PR changes `vecbuf` from a type of `streambuf` to `std::vector<char>` and uses Boost tools to allow streaming data into the vector.

## Additions

-

## Removals

-

## Changes

-

## Testing

1. Jeff confirmed these changes can create and load save states in the same way as before.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
